### PR TITLE
build: fix lint-staged glob for other files

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "**/*.{js,jsx,ts,tsx,cjs}": [
       "yarn fix:js"
     ],
-    "**/{json,md,yaml,yml}": [
+    "**/*.{json,md,yaml,yml}": [
       "yarn fix:other"
     ]
   },


### PR DESCRIPTION
## Summary
<!-- Overview of changes -->

This PR fixes the glob matching for the pre-commit hook that lints staged files with `.json`, `.yaml`, `.yml`, `.md` extensions.

### Added
<!-- List new features or components. Include a screenshot for new visual elements. -->

### Changed
<!-- List changes in existing functionality or design.
If the change was visual, include a comparison screenshot showing the before and after the visual change. -->

### Deprecated
<!-- List once-stable features or components to be deprecated in this PR. -->

### Removed
<!-- List deprecated features or components removed in this PR. -->

### Fixed
<!-- List any bug fixes. -->

- `yarn lint-staged` now correctly matches `.{json,md,yaml,yml}` files in order for the linter to run `yarn fix:other`  when matching files are detected in the staged changes.

## How to test
<!-- Instructions on how to test the changes. This is not an exhaustive list of ways you should test this PR. -->

- make a change to the README.md
- `git add README.md`
- `git commit -m "docs: update README.md`
- verify that the file is linted before the commit is made.