### PR TITLE
Revert "build(deps): bump @mui/x-data-grid from 5.17.26 to 6.3.0 (#5)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@mui/lab": "^5.0.0-alpha.129",
     "@mui/material": "^5.12.3",
     "@mui/system": "^5.12.3",
-    "@mui/x-data-grid": "^6.3.0",
+    "@mui/x-data-grid": "^5.17.26",
     "@popperjs/core": "^2.11.7",
     "aws-amplify": "^5.1.4",
     "classnames": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2857,7 +2857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.21.5
   resolution: "@babel/runtime@npm:7.21.5"
   dependencies:
@@ -4055,7 +4055,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^5.12.0, @mui/utils@npm:^5.12.3":
+"@mui/utils@npm:^5.10.3":
+  version: 5.12.0
+  resolution: "@mui/utils@npm:5.12.0"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+    "@types/prop-types": ^15.7.5
+    "@types/react-is": ^16.7.1 || ^17.0.0
+    prop-types: ^15.8.1
+    react-is: ^18.2.0
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+  checksum: 87b2c7468803b083f50af28d7c215c45291e73fef16570848b596d0f1cde1fc613c20e8951f431217b31451de254744abd50eda5013dedec4982420b5bf1c6b6
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^5.12.3":
   version: 5.12.3
   resolution: "@mui/utils@npm:5.12.3"
   dependencies:
@@ -4070,21 +4085,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/x-data-grid@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "@mui/x-data-grid@npm:6.3.0"
+"@mui/x-data-grid@npm:^5.17.26":
+  version: 5.17.26
+  resolution: "@mui/x-data-grid@npm:5.17.26"
   dependencies:
-    "@babel/runtime": ^7.21.0
-    "@mui/utils": ^5.12.0
+    "@babel/runtime": ^7.18.9
+    "@mui/utils": ^5.10.3
     clsx: ^1.2.1
     prop-types: ^15.8.1
-    reselect: ^4.1.8
+    reselect: ^4.1.6
   peerDependencies:
     "@mui/material": ^5.4.1
     "@mui/system": ^5.4.1
     react: ^17.0.2 || ^18.0.0
     react-dom: ^17.0.2 || ^18.0.0
-  checksum: 7ddfec61e597f8bb21cc90f9bed8612ed4615a2be47245ca1377f5d73c4a76613b4767aee9e0c5641057db56465528b9053bbeb71a38fced90b07adcf1589042
+  checksum: 521d9c76c7275836dda0b7ace197553142a33de702cb172cfdfbaf505379faa7566da5340eb9bdf7980909e8034b1fe0eae2b7aca6a499667ecb76f4442dc9e7
   languageName: node
   linkType: hard
 
@@ -12744,7 +12759,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reselect@npm:^4.1.8":
+"reselect@npm:^4.1.6":
   version: 4.1.8
   resolution: "reselect@npm:4.1.8"
   checksum: a4ac87cedab198769a29be92bc221c32da76cfdad6911eda67b4d3e7136dca86208c3b210e31632eae31ebd2cded18596f0dd230d3ccc9e978df22f233b5583e
@@ -13045,7 +13060,7 @@ __metadata:
     "@mui/lab": ^5.0.0-alpha.129
     "@mui/material": ^5.12.3
     "@mui/system": ^5.12.3
-    "@mui/x-data-grid": ^6.3.0
+    "@mui/x-data-grid": ^5.17.26
     "@popperjs/core": ^2.11.7
     "@semantic-release/changelog": ^6.0.3
     "@semantic-release/commit-analyzer": ^9.0.2


### PR DESCRIPTION
## Summary
<!-- Overview of changes -->

This reverts commit 4e51066c040758766a55d56e1d9facd68610a174 (#5) which introduced breaking changes in @mui/x-data-grid by @dependabot.

### Added
<!-- List new features or components. Include a screenshot for new visual elements. -->

### Changed
<!-- List changes in existing functionality or design.
If the change was visual, include a comparison screenshot showing the before and after the visual change. -->

### Deprecated
<!-- List once-stable features or components to be deprecated in this PR. -->

### Removed
<!-- List deprecated features or components removed in this PR. -->

### Fixed
<!-- List any bug fixes. -->

## How to test
<!-- Instructions on how to test the changes. This is not an exhaustive list of ways you should test this PR. -->
