### PR TITLE
fix: correct import in useAlert

### DIFF
--- a/src/hooks/useAlert.tsx
+++ b/src/hooks/useAlert.tsx
@@ -13,7 +13,7 @@ export type AlertProps = {
   timeout?: number
 }
 
-type AlertState = {
+export type AlertState = {
   isVisible: boolean
   message: string
   severity: AlertColor
@@ -25,7 +25,7 @@ const INITIAL_STATE = {
   severity: 'info' as AlertColor,
 }
 
-const AlertContext = React.createContext<{
+export const AlertContext = React.createContext<{
   state: AlertState
   clearAlert: () => void
   setAlert: (values: AlertProps) => void


### PR DESCRIPTION
## Summary

<!-- Overview of changes -->

This PR fixes an incorrect import in `src/hooks/useAlert` that causes the build to fail.

### Fixed


```
src/components/AlertMessage.test.tsx:3:10 - error TS2614: Module '"@/hooks/useAlert"' has no exported member 'AlertContext'. Did you mean to use 'import AlertContext from "@/hooks/useAlert"' instead?

3 import { AlertContext, type AlertState } from '@/hooks/useAlert'
           ~~~~~~~~~~~~

src/components/AlertMessage.test.tsx:3:29 - error TS2614: Module '"@/hooks/useAlert"' has no exported member 'AlertState'. Did you mean to use 'import AlertState from "@/hooks/useAlert"' instead?

3 import { AlertContext, type AlertState } from '@/hooks/useAlert'
                              ~~~~~~~~~~


Found 2 errors in the same file, starting at: src/components/AlertMessage.test.tsx:3

ERROR: "build" exited with 1.
```


## How to test

<!-- Instructions on how to test the changes. This is not an exhaustive list of ways you should test this PR. -->

- `yarn test`
- `yarn build`