### PR TITLE
ci(github): enable semantic-release in workflow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,4 +1,6 @@
-name: TESTS
+# Workflow that lints code, runs tests, and builds the project. On pushes
+# to the main branch, also creates a version and create a release on GitHub.
+name: CI/CD
 
 on:
   push:
@@ -13,16 +15,24 @@ on:
       - synchronize
 
 jobs:
-  frontend:
+  test_build_release:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [19]
+
+    env:
+      CI: true
+
     steps:
       - name: CHECKOUT
         uses: actions/checkout@v3
 
-      - name: INSTALL- nodejs, yarn
+      - name: INSTALL - node.js, yarn
         uses: actions/setup-node@v3
         with:
-          node-version: 19
+          node-version: ${{ matrix.node-version }}
           cache: 'yarn'
           cache-dependency-path: 'yarn.lock'
 
@@ -32,30 +42,33 @@ jobs:
           echo "npm --version: $(npm --version)"
           echo "yarn --version: $(yarn --version)"
 
-      - name: CACHE - get folder path
-        id: yarn-cache-dir-path
+      - name: CACHE - get yarn cache folder path
+        id: yarn-cache-path
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-      - name: CACHE - .yarn/
+      - name: CACHE - yarn dependencies
         id: yarn-cache
         uses: actions/cache@v3
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+          path: ${{ steps.yarn-cache-path.outputs.dir }}
+          key: node-${{ matrix.node-version }}-yarn-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
           restore-keys: |
-            yarn-cache-folder-
+            node-${{ matrix.node-version }}-yarn-
 
       - name: INSTALL - dependencies
-        run: CI=true yarn install
+        run: yarn install --immutable
 
       - name: LINT
         run: yarn lint
 
-      - name: TEST - unit
+      - name: TEST
         run: yarn test
 
       - name: BUILD
         run: yarn build
 
-      - name: VERSION
+      # semantic-release will only run on pushes to main (see package.json)
+      - name: RELEASE
         run: yarn semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,14 +1,20 @@
 {
   "name": "sbom-harbor-ui",
   "private": true,
-  "version": "0.0.0",
-  "type": "module",
+  "version": "0.0.0-semantic-release",
   "license": "UNLICENSED",
+  "description": "SBOM Harbor UI",
+  "homepage": "https://github.com/CMS-Enterprise/sbom-harbor-ui/#readme",
+  "bugs": {
+    "url": "https://github.com/CMS-Enterprise/sbom-harbor-ui/issues"
+  },
+  "type": "module",
   "scripts": {
     "start": "yarn run dev",
     "dev": "vite",
     "build": "tsc -p tsconfig.prod.json && vite build --mode production",
     "preview": "vite preview",
+    "clean": "rimraf dist",
     "test": "NODE_ENV=test jest --all --coverage --colors",
     "test:ci": "NODE_ENV=test jest --all --watchAll=false --ci",
     "test:precommit": "NODE_ENV=test jest --coverage --colors --onlyChanged --watch=false",
@@ -16,7 +22,7 @@
     "lint": "run-p 'lint:js' 'lint:other'",
     "lint:js": "eslint ./ --ext ts,tsx,js,jsx,cjs -c .eslintrc.cjs --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint --color  --report-unused-disable-directives",
     "lint:other": "prettier --check '**/*.{json,md,yaml,yml}' --ignore-path .gitignore --ignore-path .prettierignore",
-    "fix": "run-p 'fix:js' 'fix:other'",
+    "fix": "run-p 'fix:**'",
     "fix:js": "yarn run lint:js --fix",
     "fix:other": "yarn run lint:other --write",
     "semantic-release": "semantic-release",
@@ -26,7 +32,7 @@
   "packageManager": "yarn@3.5.1",
   "engines": {
     "node": "19",
-    "npm": "9.6.5",
+    "npm": "9.6.6",
     "yarn": "3.5.1"
   },
   "dependencies": {
@@ -169,30 +175,17 @@
         {
           "assets": [
             {
-              "path": "dist/index.html",
-              "label": "index.html"
+              "path": "dist",
+              "label": "Distribution"
             },
             {
-              "path": "dist/*.(svg|png|jpg|jpeg|gif|webp|ico|tif|tiff|bmp)",
-              "label": "Public images"
+              "path": "CHANGELOG.md",
+              "label": "Changelog"
             },
             {
-              "path": "dist/assets/*.js",
-              "label": "JS distribution"
-            },
-            {
-              "path": "dist/assets/*.css",
-              "label": "CSS distribution"
-            },
-            {
-              "path": "dist/assets/*.(svg|png|jpg|jpeg|gif|webp|ico|tif|tiff|bmp)",
-              "label": "IMG distribution"
-            },
-            {
-              "path": "(README|CHANGELOG).md",
-              "label": "Documentation"
-            },
-            "package.json"
+              "path": "README.md",
+              "label": "Readme"
+            }
           ]
         }
       ]


### PR DESCRIPTION
## Summary

<!-- Overview of changes -->

This PR enables semantic release versioning and updates the github action to support matrices for node versions. The version in package.json is set to `0.0.0-semantic-release` to enable semver.

When a new version is created, it will be visible in https://github.com/CMS-Enterprise/sbom-harbor-ui/releases/, and the release will contain the source code, distribution files, and the changelog/readme. Each release will look like the following:

- ![image](https://github.com/CMS-Enterprise/sbom-harbor-ui/assets/1915925/a1b2faae-53cd-4393-ae18-d0fbb73c8475)

### Added

- added description, homepage, bugs fields to package.json
- added `yarn clean` script to delete the `dist/` directory.

### Changed

- changed npm version in package.json engines
- changed names in github action workflow
- renamed workflow file from tests.yaml -> cicd.yaml

## How to test

<!-- Instructions on how to test the changes. This is not an exhaustive list of ways you should test this PR. -->

- `yarn lint`
- `yarn test`
- `yarn build`

## TODO

1. [x] Enable "Read and Write Permissions" for Workflows
    - Semantic release needs write permissions for the repository in order to be able to create versioned releases. 
    - This is done in the settings page: https://github.com/CMS-Enterprise/sbom-harbor-ui/settings/actions 
    - However, this changing this option is disabled for the repository and a support ticket needs to be created. 
    - Without write permission, the following error will be thrown:
    ```
    [3:33:43 AM] [semantic-release] › ✘  The command "git push --dry-run --no-verify https://x-access-token:[secure]@github.com/sbolel/sbom-harbor-ui HEAD:main" failed with the error message remote: Write access to repository not granted.
    fatal: unable to access 'https://github.com/sbolel/sbom-harbor-ui/': The requested URL returned error: 403.
    ```