### PR TITLE
build: add coverage output to watched tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "NODE_ENV=test jest --all --coverage --colors",
     "test:ci": "NODE_ENV=test jest --all --watchAll=false --ci",
     "test:precommit": "NODE_ENV=test jest --coverage --colors --onlyChanged --watch=false",
-    "test:watch": "NODE_ENV=test jest --onlyChanged --colors --watch",
+    "test:watch": "NODE_ENV=test jest --coverage --onlyChanged --colors --watch",
     "lint": "run-p 'lint:js' 'lint:other'",
     "lint:js": "eslint ./ --ext ts,tsx,js,jsx,cjs -c .eslintrc.cjs --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint --color  --report-unused-disable-directives",
     "lint:other": "prettier --check '**/*.{json,md,yaml,yml}' --ignore-path .gitignore --ignore-path .prettierignore",


### PR DESCRIPTION
## Summary

This PR changes the `yarn test:watch` package script so that coverage reports get outputted for changed files when watching tests.

### Added

<!-- List new features or components. Include a screenshot for new visual elements. -->

### Changed

<!-- List changes in existing functionality or design.
If the change was visual, include a comparison screenshot showing the before and after the visual change. -->

- package.json `scripts.test:watch`

### Deprecated

<!-- List once-stable features or components to be deprecated in this PR. -->

### Removed

<!-- List deprecated features or components removed in this PR. -->

### Fixed

<!-- List any bug fixes. -->

## How to test

<!-- Instructions on how to test the changes. This is not an exhaustive list of ways you should test this PR. -->

- `yarn test:watch` and then make a change to a file. you should see that the coverage of the changed file (if it has a test) will be outputted.