### PR TITLE
feat: change HashRouter to BrowserRouter

### DIFF
--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -3,7 +3,7 @@
  * @module @sbom-harbor-ui/dashboard/router
  * @see {@link @sbom-harbor-ui/dashboard/main} for usage.
  */
-import { createHashRouter } from 'react-router-dom'
+import { createBrowserRouter } from 'react-router-dom'
 import { RouteIds } from '@/types'
 
 // ** Public Views
@@ -30,10 +30,10 @@ import configureCognito from '@/utils/configureCognito'
 /**
  * The hash router for the application that defines routes
  *  and specifies the loaders for routes with dynamic data.
- * @see {@link https://reactrouter.com/web/api/HashRouter HashRouter}
+ * @see {@link https://reactrouter.com/web/api/BrowserRouter BrowserRouter}
  * @see {@link https://reactrouter.com/en/main/route/loader loader}
  */
-const router = createHashRouter([
+const router = createBrowserRouter([
   {
     id: RouteIds.MAIN,
     path: '/',


### PR DESCRIPTION
## Summary

This pull request switches the routing mechanism of the application from `HashRouter` to `BrowserRouter`. This is a significant change that affects the URL structure of the application. Previously, with `HashRouter`, URLs contained a `#` symbol before the path. For example, the URL for a page might have looked like this: `example.com/#/page`. With the change to `BrowserRouter`, the `#` symbol is no longer present in the URL, making the URLs cleaner and more user-friendly. Now, the URL for a page will look like this: `example.com/page`. 

### Added

- n/a

### Changed

- The import statement in `router.tsx` was modified from `createHashRouter` to `createBrowserRouter` from 'react-router-dom'.
- The router creation in `router.tsx` was changed from `createHashRouter` to `createBrowserRouter.
- Updated the documentation link from `HashRouter` to `BrowserRouter` in the comments section of the `router.tsx` file.

### Deprecated

- n/a

### Removed

- n/a

### Fixed

- n/a

## How to test

1. Run the application locally.
2. Navigate through the different routes of the application.
3. Check that the URLs displayed in the browser correspond to the `BrowserRouter` URL structure (without '#' symbol).
4. Verify that the routing still works as expected, with the correct components being rendered for each route.

## TODO

- [ ] (@talentedmrjones) **Add URL rewriting for AWS S3**: To ensure that the `BrowserRouter` works correctly when the app is hosted on S3, URL rewriting must be set up. This is because, unlike `HashRouter`, `BrowserRouter` can lead to `404` errors on refresh or direct access of a non-root URL in S3 without the appropriate configuration. A rule must be added to the S3 bucket's static website hosting configuration to redirect all requests to the `index.html` file. This allows React to handle the routing.