### PR TITLE
test: remove dupe extension in eslint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,7 +11,6 @@ module.exports = {
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:jest/recommended',
-    'plugin:react/jsx-runtime',
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
     'plugin:react/jsx-runtime',


### PR DESCRIPTION
## Summary

This PR removes a duplicate `extends` rule in the eslint configuration object.

### Added

- n/a

### Changed

- n/a

### Deprecated

- n/a

### Removed

- Removed duplicate key `'plugin:react/jsx-runtime'` from the `extends` property of the config object defined exported by `.eslintrc.cjs`

### Fixed

- n/a

## How to test

- `yarn` - ensure dependencies are up to date
- `yarn lint` - verify that there are no errors (warnings are okay... for now).