### PR TITLE
chore(utils): add formatBytes helper

### DIFF
--- a/src/utils/formatBytes.test.ts
+++ b/src/utils/formatBytes.test.ts
@@ -1,0 +1,40 @@
+import formatBytes from '@/utils/formatBytes'
+
+describe('formatBytes', () => {
+  it('should return 0 Bytes if input is 0', () => {
+    expect(formatBytes(0)).toBe('0 Bytes')
+  })
+
+  it('should format bytes to KB', () => {
+    expect(formatBytes(1024)).toBe('1 KB')
+  })
+
+  it('should format bytes to MB', () => {
+    expect(formatBytes(1048576)).toBe('1 MB')
+  })
+
+  it('should format bytes to GB', () => {
+    expect(formatBytes(1073741824)).toBe('1 GB')
+  })
+
+  it('should format bytes to TB', () => {
+    expect(formatBytes(1099511627776)).toBe('1 TB')
+  })
+
+  it('should format bytes to PB', () => {
+    expect(formatBytes(1125899906842624)).toBe('1 PB')
+  })
+
+  it('should format bytes to EB', () => {
+    expect(formatBytes(1152921504606846976)).toBe('1 EB')
+  })
+
+  it('should return decimal values if specified', () => {
+    expect(formatBytes(1500, 2)).toBe('1.46 KB')
+    expect(formatBytes(1500000, 2)).toBe('1.43 MB')
+  })
+
+  it('should return 0 decimal places if negative decimal is provided', () => {
+    expect(formatBytes(1500, -2)).toBe('1 KB')
+  })
+})

--- a/src/utils/formatBytes.ts
+++ b/src/utils/formatBytes.ts
@@ -1,0 +1,28 @@
+/**
+ * A utility function to format bytes into a human readable format.
+ * @module sbom-harbor-ui/utils/formatBytes
+ */
+const k = 1024
+const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+
+/**
+ * A utility function to format bytes into a human readable format.
+ * @param {number} bytes the bytes value to format
+ * @param {[number=0]} decimals the number of decimal places to include
+ * @returns {string} bytes formatted into a human readable format
+ * @example
+ *  formatBytes(1500, 2) // returns '1.46 KB'
+ *  formatBytes(1500000, 2) // returns '1.43 MB'
+ *  formatBytes(1500, -2) // returns '1 KB'
+ *  formatBytes(0) // returns '0 Bytes'
+ */
+const formatBytes = (bytes: number, decimals = 0): string => {
+  if (!+bytes) {
+    return '0 Bytes'
+  }
+  const dm = decimals < 0 ? 0 : decimals
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`
+}
+
+export default formatBytes


### PR DESCRIPTION
## Summary

This PR adds a utility function for formatting a number of bytes to a human-readable string.

### Added

- src/utils/formatBytes.ts

### Changed

- n/a

### Deprecated

- n/a

### Removed

- n/a

### Fixed

- n/a

## How to test

- `yarn`
- `yarn test`

Test coverage:
```
 PASS  src/utils/formatBytes.test.ts
  formatBytes
    ✓ should return 0 Bytes if input is 0 (1 ms)
    ✓ should format bytes to KB
    ✓ should format bytes to MB
    ✓ should format bytes to GB
    ✓ should format bytes to TB (1 ms)
    ✓ should format bytes to PB
    ✓ should format bytes to EB (1 ms)
    ✓ should return decimal values if specified
    ✓ should return 0 decimal places if negative decimal is provided (1 ms)

----------------|---------|----------|---------|---------|-------------------
File            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------|---------|----------|---------|---------|-------------------
All files       |     100 |      100 |     100 |     100 |
 formatBytes.ts |     100 |      100 |     100 |     100 |
----------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        7.851 s
```