### PR TITLE
test: ignore storybook stories for coverage

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,6 +3,7 @@ module.exports = {
   roots: ['<rootDir>/src'],
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',
+    '!src/**/*.stories.(js|jsx|ts|tsx)',
     '!src/**/*.d.ts',
     '!src/mocks/**',
   ],


### PR DESCRIPTION
## Summary

This PR changes the Jest configuration to ignore Storybook `*.stories.(ts|tsx|js|jsx)` files when collecting coverage.

### Added

- n/a

### Changed

- n/a

### Deprecated

- n/a

### Removed

- n/a

### Fixed

- n/a

## How to test

- Pull the branch and run tests with `yarn test`
- Validate that `*.stories.(tsx|ts)` files do not appear in the coverage report that is outputted.