### PR TITLE
build(dependencies): remove @mui/system, dedupe deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@mui/icons-material": "^5.11.16",
     "@mui/lab": "^5.0.0-alpha.134",
     "@mui/material": "^5.13.6",
-    "@mui/system": "^5.13.6",
     "@mui/x-data-grid": "^6.9.0",
     "@popperjs/core": "^2.11.8",
     "aws-amplify": "^5.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17861,7 +17861,6 @@ __metadata:
     "@mui/icons-material": ^5.11.16
     "@mui/lab": ^5.0.0-alpha.134
     "@mui/material": ^5.13.6
-    "@mui/system": ^5.13.6
     "@mui/x-data-grid": ^6.9.0
     "@popperjs/core": ^2.11.8
     "@semantic-release/changelog": ^6.0.3


### PR DESCRIPTION
## Summary

This Pull Request removes the redundant `@mui/system` dependency. As per the [Material UI v5 documentation](https://mui.com/material-ui/guides/understand-mui-packages/), `@mui/system` is included as a dependency in `@mui/material`, meaning that it is not necessary to install or import it separately. Components and functions can be imported directly from `@mui/material`.

### Added

- n/a

### Changed

- Ran `yarn dedupe` with the following changes to yarn.lock:
  - ```
    @mui/system@npm:^5.13.5 can be deduped from @mui/system@npm:5.13.5 to @mui/system@npm:5.13.6
    @mui/utils@npm:^5.13.1 can be deduped from @mui/utils@npm:5.13.1 to @mui/utils@npm:5.13.6
    @swc/core@npm:^1.3.61 can be deduped from @swc/core@npm:1.3.65 to @swc/core@npm:1.3.66
    @types/react@npm:* can be deduped from @types/react@npm:18.2.13 to @types/react@npm:18.2.14
    @types/react@npm:>=16 can be deduped from @types/react@npm:18.2.13 to @types/react@npm:18.2.14
    @typescript-eslint/utils@npm:^5.10.0 can be deduped from @typescript-eslint/utils@npm:5.59.11 to @typescript-eslint/utils@npm:5.60.0
    @typescript-eslint/utils@npm:^5.45.0 can be deduped from @typescript-eslint/utils@npm:5.59.11 to @typescript-eslint/utils@npm:5.60.0
    cosmiconfig@npm:^8.0.0 can be deduped from cosmiconfig@npm:8.1.3 to cosmiconfig@npm:8.2.0
    esbuild@npm:^0.17.5 can be deduped from esbuild@npm:0.17.18 to esbuild@npm:0.17.19
    postcss-modules-local-by-default@npm:^4.0.0 can be deduped from postcss-modules-local-by-default@npm:4.0.0 to postcss-modules-local-by-default@npm:4.0.3
    postcss@npm:^8.0.0 can be deduped from postcss@npm:8.4.23 to postcss@npm:8.4.24
    postcss@npm:^8.4.21 can be deduped from postcss@npm:8.4.23 to postcss@npm:8.4.24
    postcss@npm:^8.4.23 can be deduped from postcss@npm:8.4.23 to postcss@npm:8.4.24
    semver@npm:^7.0.0 can be deduped from semver@npm:7.5.0 to semver@npm:7.5.2
    semver@npm:^7.1.1 can be deduped from semver@npm:7.5.0 to semver@npm:7.5.2
    semver@npm:^7.1.2 can be deduped from semver@npm:7.5.0 to semver@npm:7.5.2
    semver@npm:^7.3.2 can be deduped from semver@npm:7.5.0 to semver@npm:7.5.2
    semver@npm:^7.3.4 can be deduped from semver@npm:7.5.0 to semver@npm:7.5.2
    semver@npm:^7.3.5 can be deduped from semver@npm:7.5.0 to semver@npm:7.5.2
    semver@npm:^7.3.7 can be deduped from semver@npm:7.5.0 to semver@npm:7.5.2
    semver@npm:^7.5.0 can be deduped from semver@npm:7.5.0 to semver@npm:7.5.2
    21 packages can be deduped using the highest strategy
    ```

### Deprecated

- n/a

### Removed

- Removed `@mui/system` from the `package.json` and `yarn.lock` files.

### Fixed

- n/a

## How to test

1. Pull the changes from this branch.
2. Run `yarn install` to update the project dependencies.
5. Run `yarn test` to ensure tests still pass.
6. Run `yarn build` to ensure build still succeeds.
7. ~Check the `node_modules` directory to ensure that the `@mui/system` package is not present.~ it will still be there because it's a dependency of other `@mui/*` packages.
