### PR TITLE
chore: disable storybook telemetry

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -17,6 +17,9 @@ const config = {
       },
     },
   },
+  core: {
+    disableTelemetry: true,
+  },
   docs: {
     autodocs: 'tag',
   },


### PR DESCRIPTION
## Summary

The changes in this Pull Request involve disabling telemetry in Storybook. Telemetry in Storybook is used to collect completely anonymous data, including general usage details such as command invocation, Storybook version, addons, and view layer. Telemetry is disabled for this project by setting `disableTelemetry: true` in the `.storybook/main.ts` configuration file.

### Added

- n/a

### Changed

- Set `disableTelemetry: true` in the `.storybook/main.ts` configuration file.

### Deprecated

- n/a

### Removed

- n/a

### Fixed

- n/a

## How to test

The disabling of telemetry doesn't directly impact the functional aspects of the application and therefore doesn't require specific functional tests. However, to confirm the changes:

1. Check the Storybook configuration in `.storybook/main.ts` and verify that `disableTelemetry: true` is set.
2. Ensure latest dependencies are installed by running `yarn`.
3. Start Storybook locally to make sure it still works as intended.
