### PR TITLE
build: upgrade @mui/x-data-grid to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@mui/lab": "^5.0.0-alpha.134",
     "@mui/material": "^5.13.6",
     "@mui/system": "^5.13.6",
-    "@mui/x-data-grid": "^5.17.26",
+    "@mui/x-data-grid": "^6.9.0",
     "@popperjs/core": "^2.11.8",
     "aws-amplify": "^5.3.1",
     "classnames": "^2.3.2",

--- a/src/views/Dashboard/Team/TeamView.tsx
+++ b/src/views/Dashboard/Team/TeamView.tsx
@@ -21,8 +21,17 @@ import { Project, Team, TeamMemberRole } from '@/types'
  * @returns {JSX.Element} A component that renders a team.
  */
 const TeamView = (): JSX.Element => {
-  // @ts-ignore
-  const { data } = useLoaderData()
+  const { data } = useLoaderData() as {
+    data: Team & {
+      membersTableRows: {
+        id: string
+        email: string
+        isTeamLead: boolean
+        role: TeamMemberRole
+        username: string
+      }[]
+    }
+  }
 
   return (
     <Paper variant="outlined" sx={{ p: 4 }}>

--- a/src/views/Dashboard/Team/components/TeamMembersTable.tsx
+++ b/src/views/Dashboard/Team/components/TeamMembersTable.tsx
@@ -112,7 +112,6 @@ const TeamMembersTable = ({ members }: InputProps) => (
       hideFooter
       rows={members}
       columns={columns}
-      disableSelectionOnClick
       pagination={undefined}
     />
   </Card>

--- a/src/views/Dashboard/Team/components/TokensTable.tsx
+++ b/src/views/Dashboard/Team/components/TokensTable.tsx
@@ -15,7 +15,7 @@ import {
   DataGrid,
   GridActionsCell,
   GridActionsCellItem,
-  GridColumns,
+  GridColDef,
   GridRowId,
   GridRowParams,
 } from '@mui/x-data-grid'
@@ -50,7 +50,7 @@ type TokenRow = {
   loading: boolean
 } & Token
 
-type RenderCellProps = {
+type GridRenderCellParams = {
   row: Token
 }
 
@@ -259,13 +259,15 @@ const TokensTable = ({ teamId, tokens }: InputProps) => {
   /**
    * The column definitions for the TokensTable DataGrid.
    */
-  const columns = React.useMemo<GridColumns<TokenRow>>(
+  const columns = React.useMemo<GridColDef[]>(
     () => [
       {
         flex: 0.35,
         field: 'name',
         headerName: 'Description',
-        renderCell: ({ row: { name, id } }: RenderCellProps): JSX.Element => (
+        renderCell: ({
+          row: { name, id },
+        }: GridRenderCellParams): JSX.Element => (
           <Typography variant="body2">{name || id}</Typography>
         ),
       },
@@ -273,7 +275,9 @@ const TokensTable = ({ teamId, tokens }: InputProps) => {
         flex: 0.125,
         field: 'created',
         headerName: 'Created',
-        renderCell: ({ row: { created } }: RenderCellProps): JSX.Element => (
+        renderCell: ({
+          row: { created },
+        }: GridRenderCellParams): JSX.Element => (
           <DateLocaleString date={new Date(created)} />
         ),
         defaultSort: 'desc',
@@ -282,7 +286,9 @@ const TokensTable = ({ teamId, tokens }: InputProps) => {
         flex: 0.125,
         field: 'expires',
         headerName: 'Expires',
-        renderCell: ({ row: { expires } }: RenderCellProps): JSX.Element => (
+        renderCell: ({
+          row: { expires },
+        }: GridRenderCellParams): JSX.Element => (
           <DateLocaleString date={new Date(expires)} />
         ),
       },
@@ -290,7 +296,9 @@ const TokensTable = ({ teamId, tokens }: InputProps) => {
         flex: 0.125,
         field: 'expired',
         headerName: 'Expired?',
-        renderCell: ({ row: { expires } }: RenderCellProps): JSX.Element => {
+        renderCell: ({
+          row: { expires },
+        }: GridRenderCellParams): JSX.Element => {
           const isExpired = new Date() > new Date(expires)
           return (
             <Typography
@@ -306,7 +314,9 @@ const TokensTable = ({ teamId, tokens }: InputProps) => {
         flex: 0.125,
         field: 'enabled',
         headerName: 'Enabled?',
-        renderCell: ({ row: { enabled } }: RenderCellProps): JSX.Element => (
+        renderCell: ({
+          row: { enabled },
+        }: GridRenderCellParams): JSX.Element => (
           <Typography
             variant="caption"
             sx={{ color: !enabled ? 'red' : 'green', width: '100%' }}
@@ -320,7 +330,7 @@ const TokensTable = ({ teamId, tokens }: InputProps) => {
         type: 'actions',
         width: 80,
         cellClassName: 'MuiDataGrid-cell--full-width ',
-        renderCell: (params): JSX.Element => {
+        renderCell: (params: any): JSX.Element => {
           if (params.row.loading) {
             params.focusElementRef = null
             return (
@@ -368,7 +378,6 @@ const TokensTable = ({ teamId, tokens }: InputProps) => {
           columns={columns}
           rows={rows}
           autoHeight
-          disableSelectionOnClick
           getRowClassName={({ row: { loading = false } = {} }) =>
             `row-loading-${loading}`
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3846,7 +3846,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.17.8, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.22.5, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
   version: 7.22.5
   resolution: "@babel/runtime@npm:7.22.5"
   dependencies:
@@ -5308,7 +5308,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/utils@npm:^5.10.3, @mui/utils@npm:^5.13.1, @mui/utils@npm:^5.13.6":
+"@mui/utils@npm:^5.13.1":
+  version: 5.13.1
+  resolution: "@mui/utils@npm:5.13.1"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+    "@types/prop-types": ^15.7.5
+    "@types/react-is": ^18.2.0
+    prop-types: ^15.8.1
+    react-is: ^18.2.0
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+  checksum: 79cfc91e5a61311ac88680df3ea09f1218d0a5a766b6dadf0c5c9c72a3c36cbd903895ebb0f16497dcffb2e3601cb3b46742ae3c5e2c1f62d5ebf02babfd910f
+  languageName: node
+  linkType: hard
+
+"@mui/utils@npm:^5.13.6":
   version: 5.13.6
   resolution: "@mui/utils@npm:5.13.6"
   dependencies:
@@ -5323,21 +5338,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mui/x-data-grid@npm:^5.17.26":
-  version: 5.17.26
-  resolution: "@mui/x-data-grid@npm:5.17.26"
+"@mui/x-data-grid@npm:^6.9.0":
+  version: 6.9.0
+  resolution: "@mui/x-data-grid@npm:6.9.0"
   dependencies:
-    "@babel/runtime": ^7.18.9
-    "@mui/utils": ^5.10.3
+    "@babel/runtime": ^7.22.5
+    "@mui/utils": ^5.13.1
     clsx: ^1.2.1
     prop-types: ^15.8.1
-    reselect: ^4.1.6
+    reselect: ^4.1.8
   peerDependencies:
     "@mui/material": ^5.4.1
     "@mui/system": ^5.4.1
-    react: ^17.0.2 || ^18.0.0
-    react-dom: ^17.0.2 || ^18.0.0
-  checksum: 521d9c76c7275836dda0b7ace197553142a33de702cb172cfdfbaf505379faa7566da5340eb9bdf7980909e8034b1fe0eae2b7aca6a499667ecb76f4442dc9e7
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+  checksum: e18cf234ef07460f60b38760301dd2508f49daefd10432e9f35c7a8862ebccc9e58ed5850a206c4c7e2f18bdce2a514262e9c71373a4f766d5fa37e4bf3d3186
   languageName: node
   linkType: hard
 
@@ -17497,7 +17512,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reselect@npm:^4.1.6":
+"reselect@npm:^4.1.8":
   version: 4.1.8
   resolution: "reselect@npm:4.1.8"
   checksum: a4ac87cedab198769a29be92bc221c32da76cfdad6911eda67b4d3e7136dca86208c3b210e31632eae31ebd2cded18596f0dd230d3ccc9e978df22f233b5583e
@@ -17847,7 +17862,7 @@ __metadata:
     "@mui/lab": ^5.0.0-alpha.134
     "@mui/material": ^5.13.6
     "@mui/system": ^5.13.6
-    "@mui/x-data-grid": ^5.17.26
+    "@mui/x-data-grid": ^6.9.0
     "@popperjs/core": ^2.11.8
     "@semantic-release/changelog": ^6.0.3
     "@semantic-release/commit-analyzer": ^10.0.1


### PR DESCRIPTION
## Summary

This PR upgrades the `@mui/x-data-grid` package from v5 to v6, a major version upgrade that introduces some backward incompatible changes. This upgrade is preparation for Upload UI v2, enabling the use of the newest features of MUI Data Grid. To accommodate these changes, the `disableSelectionOnClick` prop, no longer supported in v6, has been removed from all instances where it was used. Additionally, the `GridColumns` import has been renamed to `GridColDef`, following the changes in the package's API.

Additionally, an explicit type has been added to the `useLoaderData` call in the `TeamView` component.

### Added

- Added explicit type to `useLoaderData` call in `TeamView` component.

### Changed

- Upgraded `@mui/x-data-grid` to v6.
- Renamed deprecated `GridColumns` import to `GridColDef` across the codebase.

### Deprecated

- _n/a_

### Removed

- Removed the `disableSelectionOnClick` prop from all instances of the MUI `Grid` component where it was used.

### Fixed

- _n/a_

## How to test

Given that the changes involve an upgrade to a major package version and modifications to the codebase to accommodate the upgrade, a thorough test of all the components that use the `Grid` component would normally be necessary. However, since none of the components are actually being rendered after the deprecation of the v1 UI, there is nothing that needs manual verification.

1. Pull the changes from this branch.
2. Run `yarn install` to update the project dependencies.
3. Run `yarn test` to confirm tests still pass.
4. Run `yarn build` to confirm build still succeeds.