### PR TITLE
refactor: annotate types in SignIn view

### DIFF
--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -6,6 +6,7 @@ import * as React from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { useForm, Controller } from 'react-hook-form'
 import { Auth } from 'aws-amplify'
+import { type FederatedSignInOptions } from '@aws-amplify/auth/lib/types'
 import * as yup from 'yup'
 import { yupResolver } from '@hookform/resolvers/yup'
 import Box from '@mui/material/Box'
@@ -81,8 +82,9 @@ const LoginPage = () => {
 
   const handleClickFederatedSignIn = async () => {
     try {
-      // @ts-ignore
-      await Auth.federatedSignIn({ provider: 'COGNITO' })
+      await Auth.federatedSignIn({
+        provider: 'COGNITO',
+      } as FederatedSignInOptions)
     } catch (error) {
       console.error('Error signing in with Google', error)
     }
@@ -92,7 +94,8 @@ const LoginPage = () => {
     const { email, password } = data
     setLoading(true)
     try {
-      // @ts-ignore
+      // FIXME: correct type error in loginUser action
+      // @ts-expect-error
       await loginUser(dispatch, { email, password })
       setLoading(false)
       navigate('/app')


### PR DESCRIPTION
## Summary

This pull request introduces type safety to the federated sign-in logic in the `SignIn` view. The `FederatedSignInOptions` type from the `@aws-amplify/auth` library is now utilized for the `Auth.federatedSignIn` method call. The type definition is imported and used to type the options object passed into the `Auth.federatedSignIn` call.

### Added

- Type `FederatedSignInOptions` imported from `@aws-amplify/auth/lib/types`.

### Changed

- Imported `FederatedSignInOptions` type from `@aws-amplify/auth/lib/types` and applied it to the `Auth.federatedSignIn` method call in `SignIn` view.
- Replaced `@ts-ignore` comment with `@ts-expect-error` comment in the `loginUser` action invocation.

### Removed

- The `@ts-ignore` comment above the `Auth.federatedSignIn` method call is removed.

## How to test

1. Clone this branch and install the necessary dependencies.
2. Run the application.
3. Navigate to the sign-in page and attempt to sign in.
4. Ensure that the federated sign-in feature still works as expected, and no type errors are shown in the console or during the build process.