### PR TITLE
test(hooks): add test coverage and Storybook stories for useAlert

### DIFF
--- a/src/hooks/stories/useAlert.stories.tsx
+++ b/src/hooks/stories/useAlert.stories.tsx
@@ -1,0 +1,103 @@
+import type { StoryObj, Meta } from '@storybook/react'
+import { styled } from '@mui/material/styles'
+import MuiAlert, { AlertColor } from '@mui/material/Alert'
+import Box from '@mui/material/Box'
+import MuiButton from '@mui/material/Button'
+import { DEFAULT_ALERT_TIMEOUT } from '@/constants'
+import { AlertProvider, useAlert, type AlertProps } from '@/hooks/useAlert'
+
+const DEFAULT_MESSAGE = 'Hello World!'
+const DEFAULT_SEVERITY: AlertColor = 'info'
+
+const Button = styled(MuiButton)({
+  position: 'absolute',
+  bottom: 10,
+  right: 10,
+})
+
+Button.defaultProps = { variant: 'contained', size: 'large' }
+
+const AlertComponent = ({
+  autoHide = true,
+  message = DEFAULT_MESSAGE,
+  severity = DEFAULT_SEVERITY,
+  timeout = DEFAULT_ALERT_TIMEOUT,
+}: AlertProps) => {
+  const {
+    clearAlert,
+    setAlert,
+    state: { isVisible },
+  } = useAlert()
+
+  return (
+    <Box>
+      {isVisible && (
+        <MuiAlert severity={severity} onClose={clearAlert}>
+          {message}
+        </MuiAlert>
+      )}
+      {!isVisible && (
+        <Button
+          onClick={() =>
+            setAlert({
+              autoHide,
+              message,
+              severity,
+              timeout,
+            })
+          }
+        >
+          Show alert
+        </Button>
+      )}
+      {isVisible && <Button onClick={clearAlert}>Clear alert</Button>}
+    </Box>
+  )
+}
+
+type Story = StoryObj<AlertProps>
+
+export default {
+  title: 'Hooks/Alerts',
+  component: AlertComponent,
+  decorators: [
+    (StoryNode, { args }) => (
+      <AlertProvider {...args}>
+        <StoryNode />
+      </AlertProvider>
+    ),
+  ],
+  argTypes: {
+    autoHide: {
+      control: 'boolean',
+      defaultValue: true,
+    },
+    message: {
+      control: 'text',
+      defaultValue: DEFAULT_MESSAGE,
+    },
+    severity: {
+      control: 'select',
+      defaultValue: DEFAULT_SEVERITY,
+      options: ['success', 'error', 'info'],
+    },
+    timeout: {
+      control: 'number',
+      defaultValue: DEFAULT_ALERT_TIMEOUT,
+    },
+  },
+} as Meta<Story>
+
+export const Playground: Story = {
+  render: (_, { args }) => <AlertComponent {...args} />,
+}
+
+Playground.parameters = {
+  title: 'Hooks/Alerts/Playground',
+  defaultValues: {
+    autoHide: true,
+    message: DEFAULT_MESSAGE,
+    severity: DEFAULT_SEVERITY,
+    timeout: DEFAULT_ALERT_TIMEOUT,
+  },
+}

--- a/src/hooks/useAlert.test.tsx
+++ b/src/hooks/useAlert.test.tsx
@@ -1,0 +1,148 @@
+import { Root, createRoot } from 'react-dom/client'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { AlertColor } from '@mui/material/Alert'
+import { AlertProvider, AlertState, useAlert } from '@/hooks/useAlert'
+
+const TIMEOUT = 100
+
+describe('useAlert', () => {
+  let root: Root
+  const mockClearAlert = jest.fn()
+  const mockSetAlert = jest.fn()
+  const mockSetData = jest.fn()
+
+  const successAlert = {
+    autoHide: true,
+    message: 'Test message',
+    severity: 'success' as AlertColor,
+    timeout: TIMEOUT,
+  }
+
+  const successState = {
+    isVisible: true,
+    message: 'Test message',
+    severity: 'success',
+  } as AlertState
+
+  const errorMessage = 'Something went wrong'
+
+  const errorAlert = {
+    autoHide: true,
+    message: errorMessage,
+    severity: 'error' as AlertColor,
+    timeout: TIMEOUT,
+  }
+
+  const initialState = {
+    isVisible: false,
+    message: '',
+    severity: 'info' as AlertColor,
+  } as AlertState
+
+  const Wrapper = ({ children }: { children: JSX.Element }) => (
+    <AlertProvider
+      contextOverrides={{
+        clearAlert: mockClearAlert,
+        setAlert: mockSetAlert,
+        setData: mockSetData,
+      }}
+    >
+      {children}
+    </AlertProvider>
+  )
+
+  const RenderNodes = () => (
+    <Wrapper>
+      <div>Test</div>
+    </Wrapper>
+  )
+
+  beforeAll(() => {
+    jest.useFakeTimers()
+  })
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    root = createRoot(document.createElement('div'))
+    await act(() => {
+      root.render(<RenderNodes />)
+    })
+  })
+
+  afterAll(() => {
+    jest.useRealTimers()
+  })
+
+  it('should set and clear alert', async () => {
+    const { result } = renderHook(() => useAlert(), { wrapper: Wrapper })
+    await act(() => {
+      result.current.setAlert(successAlert)
+    })
+    await waitFor(() => {
+      expect(result.current.state).toEqual(successState)
+    })
+    await waitFor(
+      () => {
+        expect(result.current.state).toEqual(initialState)
+      },
+      { timeout: TIMEOUT + 10 }
+    )
+  })
+
+  it('should not clear alert if it is cleared before DEFAULT_ALERT_TIMEOUT', async () => {
+    const { result } = renderHook(() => useAlert(), { wrapper: Wrapper })
+    await act(() => {
+      result.current.setAlert(successAlert)
+    })
+    await waitFor(() => {
+      expect(result.current.state).toEqual(successState)
+    })
+    await act(() => {
+      result.current.clearAlert()
+    })
+    await waitFor(() => {
+      expect(result.current.state).toEqual(initialState)
+    })
+  })
+
+  it('updates the alert state', async () => {
+    const { result } = renderHook(() => useAlert(), { wrapper: Wrapper })
+    await act(() => {
+      result.current.setAlert(errorAlert)
+    })
+    expect(result.current.state.severity).toBe('error')
+    expect(result.current.state.message).toBe(errorMessage)
+  })
+
+  it('clears the alert state after timeout passes', async () => {
+    const { result } = renderHook(() => useAlert(), { wrapper: Wrapper })
+    await act(() => {
+      result.current.setAlert(errorAlert)
+    })
+    await waitFor(() => expect(result.current.state.severity).toBe('info'), {
+      timeout: TIMEOUT + 100,
+    })
+  })
+
+  it('should call setData if implemented as a controlled component', async () => {
+    const { result } = renderHook(() => useAlert(), { wrapper: Wrapper })
+    await act(() => {
+      result.current.setData(successState)
+    })
+    await waitFor(() => {
+      expect(result.current.state).toEqual(successState)
+      expect(mockSetData).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('should call default setData if not implemented as a controlled component', async () => {
+    const { result } = renderHook(() => useAlert())
+    await act(() => {
+      result.current.setData(successState)
+    })
+    await waitFor(() => {
+      expect(result.current.state).toEqual(initialState)
+      expect(mockSetData).toHaveBeenCalledTimes(0)
+    })
+  })
+})

--- a/src/main.test.tsx
+++ b/src/main.test.tsx
@@ -1,4 +1,3 @@
-import { RouterProviderProps } from 'react-router-dom'
 import { type AppConfig } from '@/utils/config'
 
 /**


### PR DESCRIPTION
## Summary

This PR focuses on increasing the test coverage for our React Hooks, specifically the `useAlert` hook, as well as adding corresponding Storybook stories for visual testing and documentation. 

### Added

- Added unit tests for `useAlert` hook to ensure that it behaves as expected in various scenarios.
- Added Storybook stories for `useAlert` hook with an interactive "`Playground`", providing visual confirmation and documentation of the hook's behaviour when used in conjunction with the `Alert` component.

### Changed

- Refactored the `useAlert` hook to support being used as a controlled hook component (allowing for easier testing).

### Deprecated

- n/a

### Removed

- Removed unused import from main.tsx

### Fixed

- n/a

## How to test

You can test these changes by running the following commands:

- `yarn lint` - verify that there are no linter errors
- `yarn test` - verify all tests still pass
- `yarn build` - verify build still succeeds

Then, use Storybook to interact with the `useAlert` hook and the `Alert` component.

- `yarn storybook`: Start Storybook dev server.
- Navigate to the Alerts/Playground story in the left menu.
- Click the button in the bottom right to show and clear the alert.

Test coverage:

```
-------------------------------------|---------|----------|---------|---------|---------------------------
File                                 | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-------------------------------------|---------|----------|---------|---------|---------------------------
All files                            |   59.48 |    27.27 |    21.6 |   59.25 |
 src                                 |   98.63 |      100 |     100 |     100 |
 src/hooks                           |   38.79 |    26.82 |   21.42 |   35.97 |
  useAlert.tsx                       |    92.1 |    52.38 |   77.77 |   93.54 | 37-38
```