### PR TITLE
build: ignore coverage files for HMR

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,5 +15,10 @@ export default defineConfig({
     },
   },
   plugins: [react(), EnvironmentPlugin('all'), visualizer() as PluginOption],
+  server: {
+    watch: {
+      ignored: ['**/coverage/**'],
+    },
+  },
   appType: 'spa',
 })


### PR DESCRIPTION
## Summary

This PR updates the Vite server configuration to ignore file changes in the coverage directory, which helps optimize the hot module reload (HMR) process.

### Added

- Added an 'ignored' property to the Vite server watch configuration. This property specifies an array of glob patterns, with `'**/coverage/**'` currently defined to ignore all files in any coverage directory. 

### Changed

- No existing functionality has been modified outside of the added configuration.

### Deprecated

- No features or components have been marked for deprecation.

### Removed

- No features or components have been removed.

### Fixed

- This configuration update indirectly addresses any potential performance or unnecessary HMR triggers caused by changes in coverage files during development.

## How to test

- After pulling the changes, start the local development server with `yarn start`
- While the server is running, make changes to files within a coverage directory or run `yarn test` and observe that HMR does not get triggered. 
- Verify that changes to other files (not in the coverage directory) still trigger HMR as expected.