### PR TITLE
test(hooks/useCopyToClipboard): add tests, remove console logs

### DIFF
--- a/src/hooks/useCopyToClipboard.test.ts
+++ b/src/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,73 @@
+import { act, renderHook } from '@testing-library/react'
+import useCopyToClipboard from '../hooks/useCopyToClipboard'
+
+describe('useCopyToClipboard', () => {
+  it('should copy text to clipboard and clear it', async () => {
+    const { result } = renderHook(() => useCopyToClipboard())
+    const [copiedText, copy, clear] = result.current
+
+    // Initially, copiedText should be null
+    expect(copiedText).toBeNull()
+
+    // Mock the clipboard API
+    // @ts-expect-error
+    global.navigator.clipboard = {
+      writeText: jest.fn().mockResolvedValue(undefined),
+    }
+
+    // Copy text
+    await act(async () => {
+      const success = await copy('test')
+      expect(success).toBe(true)
+    })
+
+    // Check if the text is copied
+    expect(result.current[0]).toBe('test')
+
+    // Clear the copied text
+    act(() => {
+      clear()
+    })
+
+    // Check if the copied text is cleared
+    expect(result.current[0]).toBeNull()
+  })
+
+  it('should handle errors when copying text', async () => {
+    const { result } = renderHook(() => useCopyToClipboard())
+    const [, copy] = result.current
+
+    // Mock the clipboard API to throw an error
+    // @ts-expect-error
+    global.navigator.clipboard = {
+      writeText: jest.fn().mockRejectedValue(new Error('Failed to copy text')),
+    }
+
+    // Try to copy text
+    await act(async () => {
+      const success = await copy('test')
+      expect(success).toBe(false)
+    })
+
+    // Check if the copied text is null
+    expect(result.current[0]).toBeNull()
+  })
+
+  it('should return false when clipboard API is not supported', async () => {
+    const { result } = renderHook(() => useCopyToClipboard())
+    const [, copy] = result.current
+
+    // Mock the clipboard API to be undefined
+    // @ts-expect-error
+    global.navigator.clipboard = undefined
+
+    // Try to copy text
+    await act(async () => {
+      const success = await copy('test')
+      expect(success).toBe(false)
+    })
+
+    // Check if the copied text is null
+    expect(result.current[0]).toBeNull()
+  })
+})

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,20 +1,25 @@
 /**
+ * Custom hook to copy text to clipboard.
  * @module sbom-harbor-ui/hooks/useCopyToClipboard
  */
-import * as React from 'react'
+import { useState } from 'react'
 
-type CopiedValue = string | null
-type CopyFn = (text: string) => Promise<boolean> // Return success
-type ClearFn = () => void
+export type CopiedValue = string | null
+export type CopyFn = (text: string) => Promise<boolean> // Return success
+export type ClearFn = () => void
 
+/**
+ * Hook to copy text to clipboard.
+ * @returns {[CopiedValue, CopyFn, ClearFn]} [copiedText, copy, clear]
+ */
 function useCopyToClipboard(): [CopiedValue, CopyFn, ClearFn] {
-  const [copiedText, setCopiedText] = React.useState<CopiedValue>(null)
+  const [copiedText, setCopiedText] = useState<CopiedValue>(null)
 
   const clear = () => setCopiedText(null)
 
   const copy: CopyFn = async (text) => {
     if (!navigator?.clipboard) {
-      console.warn('Clipboard not supported')
+      // Clipboard not supported
       return false
     }
 
@@ -24,7 +29,6 @@ function useCopyToClipboard(): [CopiedValue, CopyFn, ClearFn] {
       setCopiedText(text)
       return true
     } catch (error) {
-      console.warn('Copy failed', error)
       setCopiedText(null)
       return false
     }


### PR DESCRIPTION
## Summary

This PR adds test coverage for the `useCopyToClipboard` custom hook.

### Added

- [src/hooks/useCopyToClipboard.test.ts](https://github.com/CMS-Enterprise/sbom-harbor-ui/compare/test/hooks/useCopyToClipboard?expand=1#diff-c408cfd3bc9e23bf8f048b1fe73b7dbcecf63e0f9238146655373e2698ea8612)

### Changed

- renamed `useCopyToClipboard.tsx` to `useCopyToClipboard.ts`
- removed `console` statements in `useCopyToClipboard.ts`

### Deprecated

- n/a

### Removed

- n/a

### Fixed

- n/a

## How to test

- `yarn test` (tests pass if the github workflow is passing, no action needed)

**Test Coverage:**

```
-----------------------|---------|----------|---------|---------|-------------------
File                   | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------|---------|----------|---------|---------|-------------------
All files              |     100 |      100 |     100 |     100 |
 useCopyToClipboard.ts |     100 |      100 |     100 |     100 |
-----------------------|---------|----------|---------|---------|-------------------
```