### PR TITLE
build: remove testing-library/react-hooks dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.4.3",
     "@types/babel__core": "^7",
     "@types/jest": "^29.5.3",

--- a/src/actions/logoutUser.test.tsx
+++ b/src/actions/logoutUser.test.tsx
@@ -1,4 +1,4 @@
-import { act } from '@testing-library/react-hooks'
+import { act } from '@testing-library/react'
 import { Auth } from 'aws-amplify'
 import logoutUser from '@/actions/logoutUser'
 import { AuthActions } from '@/actions/actionTypes'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7034,28 +7034,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react-hooks@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "@testing-library/react-hooks@npm:8.0.1"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-    react-error-boundary: ^3.1.0
-  peerDependencies:
-    "@types/react": ^16.9.0 || ^17.0.0
-    react: ^16.9.0 || ^17.0.0
-    react-dom: ^16.9.0 || ^17.0.0
-    react-test-renderer: ^16.9.0 || ^17.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    react-dom:
-      optional: true
-    react-test-renderer:
-      optional: true
-  checksum: 7fe44352e920deb5cb1876f80d64e48615232072c9d5382f1e0284b3aab46bb1c659a040b774c45cdf084a5257b8fe463f7e08695ad8480d8a15635d4d3d1f6d
-  languageName: node
-  linkType: hard
-
 "@testing-library/react@npm:*, @testing-library/react@npm:^14.0.0":
   version: 14.0.0
   resolution: "@testing-library/react@npm:14.0.0"
@@ -16909,17 +16887,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-error-boundary@npm:^3.1.0":
-  version: 3.1.4
-  resolution: "react-error-boundary@npm:3.1.4"
-  dependencies:
-    "@babel/runtime": ^7.12.5
-  peerDependencies:
-    react: ">=16.13.1"
-  checksum: f36270a5d775a25c8920f854c0d91649ceea417b15b5bc51e270a959b0476647bb79abb4da3be7dd9a4597b029214e8fe43ea914a7f16fa7543c91f784977f1b
-  languageName: node
-  linkType: hard
-
 "react-fast-compare@npm:^3.0.1":
   version: 3.2.1
   resolution: "react-fast-compare@npm:3.2.1"
@@ -17772,7 +17739,6 @@ __metadata:
     "@testing-library/dom": ^9.3.1
     "@testing-library/jest-dom": ^5.17.0
     "@testing-library/react": ^14.0.0
-    "@testing-library/react-hooks": ^8.0.1
     "@testing-library/user-event": ^14.4.3
     "@types/babel__core": ^7
     "@types/jest": ^29.5.3


### PR DESCRIPTION
## Summary

This PR removes `@testing-library/react-hooks` in favor of `@testing-library/react` as per the [documentation](https://github.com/testing-library/react-hooks-testing-library#a-note-about-react-18-support), which states:

<blockquote>
<h2>A Note about React 18 Support</h2>

If you are using the current version of `react-testing-library`, replace

```js
import { renderHook } from '@testing-library/react-hooks'
```

with

```js
import { renderHook } from '@testing-library/react'
```

Once replaced, `@testing-library/react-hooks` can be uninstalled.
</blockquote>

### Added

- n/a

### Changed

- `import { act } from '@testing-library/react-hooks'` in `src/actions/logoutUser` changed to `import { act } from '@testing-library/react'`

### Deprecated

- n/a

### Removed

- removed `@testing-library/react-hooks` dev dependency

### Fixed

- n/a

## How to test

- `yarn test` (tests pass if the github workflow is passing, no action needed)
