### PR TITLE
refactor(utils/sanitizeUrl): support all protocols in url

### DIFF
--- a/src/errors/AuthError.test.ts
+++ b/src/errors/AuthError.test.ts
@@ -1,0 +1,45 @@
+import AuthError, {
+  AuthErrorStatus,
+  AuthErrorStatusText,
+} from '@/errors/AuthError'
+
+describe('AuthError', () => {
+  it('should be an instance of "AuthError" and capture the stack trace', () => {
+    const error = new AuthError()
+    expect(error).toBeInstanceOf(AuthError)
+    expect(error.name).toBe('AuthError')
+    expect(error.stack).toBeDefined()
+  })
+
+  it('should create an error with a default status of 401', () => {
+    const error = new AuthError()
+    expect(error.status).toBe(AuthErrorStatus.UNAUTHORIZED)
+    expect(error.statusText).toBe(AuthErrorStatusText.UNAUTHORIZED)
+    expect(error.message).toBe(AuthErrorStatusText.UNAUTHORIZED)
+  })
+
+  it('should create a Forbidden error with a status of 403', () => {
+    const error = new AuthError({ status: 403 })
+    expect(error.status).toBe(AuthErrorStatus.FORBIDDEN)
+  })
+
+  it('should create an instance of AuthError with custom message', () => {
+    const message = 'Invalid Session'
+    const error = new AuthError({ message })
+    expect(error.message).toBe(message)
+  })
+
+  it('should default key to UNKNOWN when status code does not match any predefined status codes', () => {
+    const error = new AuthError({ status: 999 })
+    expect(error.status).toBe(999)
+    expect(error.statusText).toBe(AuthErrorStatusText.UNKNOWN)
+  })
+
+  it('should have a Response object in the response property', () => {
+    const error = new AuthError({ status: 401 })
+    const response = error.toResponse()
+    expect(response).toBeInstanceOf(Response)
+    expect(response.status).toBe(AuthErrorStatus.UNAUTHORIZED)
+    expect(response.statusText).toBe(AuthErrorStatusText.UNAUTHORIZED)
+  })
+})

--- a/src/errors/AuthError.ts
+++ b/src/errors/AuthError.ts
@@ -1,0 +1,93 @@
+/**
+ * @module sbom-harbor-ui/errors/AuthError
+ * @see {@link @sbom-harbor-ui/utils/getJWT}
+ * @see {@link @sbom-harbor-ui/router/authLoader}
+ */
+
+export enum AuthErrorKeys {
+  UNAUTHORIZED = 'UNAUTHORIZED',
+  FORBIDDEN = 'FORBIDDEN',
+  UNKNOWN = 'UNKNOWN',
+}
+
+export enum AuthErrorStatusText {
+  UNAUTHORIZED = 'Unauthorized',
+  FORBIDDEN = 'Forbidden',
+  UNKNOWN = 'Unknown Error',
+}
+
+export enum AuthErrorStatus {
+  UNAUTHORIZED = 401,
+  FORBIDDEN = 403,
+  UNKNOWN = 500,
+}
+
+const Entries = Object.entries(AuthErrorStatus) as [string, AuthErrorStatus][]
+
+/**
+ * Custom error class for authentication errors
+ * @param {string} message - Error message
+ * @param {number} status - HTTP status code
+ * @returns {AuthError} An instance of AuthError
+ * @example
+ * throw new AuthError('Invalid Session', { status: 401 })
+ */
+class AuthError extends Error {
+  #key: AuthErrorKeys
+  #status: number
+  #statusText: string
+  #message: string
+
+  constructor({
+    status = 401,
+    message,
+  }: {
+    status?: number
+    message?: string | AuthErrorStatusText
+  } = {}) {
+    super(message)
+
+    // Ensure the name of this error is the same as the class name
+    this.name = 'AuthError'
+
+    // Assign the error message
+    this.#message = message as string
+
+    // If a status code is provided, assign it, otherwise default to 401
+    this.#status = status
+
+    // Get the enum key from the status code
+    this.#key = (Entries.find(
+      ([, value]: [string, AuthErrorStatus]) => value === this.#status
+    )?.[0] || AuthErrorKeys.UNKNOWN) as AuthErrorKeys
+
+    // Get the status text from the enum key
+    this.#statusText = AuthErrorStatusText[this.#key]
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AuthError)
+    }
+  }
+
+  get status(): number {
+    return this.#status
+  }
+
+  get statusText(): string {
+    return this.#statusText
+  }
+
+  get message(): string {
+    return this.#message || this.#statusText
+  }
+
+  toResponse(): Response {
+    return new Response(this.message, {
+      status: this.#status,
+      statusText: this.#statusText,
+    })
+  }
+}
+
+export default AuthError

--- a/src/utils/getJWT.test.ts
+++ b/src/utils/getJWT.test.ts
@@ -1,0 +1,38 @@
+import { Auth } from 'aws-amplify'
+import getJWT from '@/utils/getJWT'
+import { AuthErrorStatus } from '@/errors/AuthError'
+
+describe('getJWT', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns the JWT token when the session is valid', async () => {
+    const mockSession = {
+      getAccessToken: jest
+        .fn()
+        .mockReturnValue({ getJwtToken: jest.fn().mockReturnValue('123456') }),
+    }
+    // @ts-expect-error
+    Auth.currentSession.mockResolvedValue(mockSession)
+    await expect(getJWT()).resolves.toBe('123456')
+    expect(Auth.currentSession).toHaveBeenCalled()
+    expect(mockSession.getAccessToken).toHaveBeenCalled()
+  })
+
+  it('returns a 401 Response when the session is invalid', async () => {
+    const mockSession = {
+      getAccessToken: jest
+        .fn()
+        .mockReturnValue({ getJwtToken: jest.fn().mockReturnValue(null) }),
+    }
+    // @ts-expect-error
+    Auth.currentSession.mockResolvedValue(mockSession)
+    const promise = getJWT()
+    await expect(promise).rejects.toBeInstanceOf(Response)
+    await expect(promise).rejects.toHaveProperty(
+      'status',
+      AuthErrorStatus.UNAUTHORIZED
+    )
+  })
+})

--- a/src/utils/getJWT.ts
+++ b/src/utils/getJWT.ts
@@ -3,20 +3,21 @@
  * @module sbom-harbor-ui/utils/getJWT
  */
 import { Auth } from 'aws-amplify'
+import AuthError from '@/errors/AuthError'
 
 /**
  * Get the Cognito JWT Token from the current session.
  * @returns {Promise<string>} The Cognito JWT Token.
  */
-const getJWT = (): Promise<string> =>
-  Auth.currentSession().then((session) => {
-    const jwtToken = session.getAccessToken().getJwtToken()
+const getJWT = async (): Promise<string> => {
+  const session = await Auth.currentSession()
+  const jwtToken = session.getAccessToken().getJwtToken()
 
-    if (!jwtToken) {
-      throw new Response('Invalid Session', { status: 401 })
-    }
+  if (!jwtToken) {
+    throw new AuthError().toResponse()
+  }
 
-    return jwtToken
-  })
+  return jwtToken
+}
 
 export default getJWT

--- a/src/utils/sanitizeUrl.test.ts
+++ b/src/utils/sanitizeUrl.test.ts
@@ -1,19 +1,15 @@
 import sanitizeUrl from '@/utils/sanitizeUrl'
 
-const origin = 'test.cloudfront.net'
-const route = '/api/v1/teams'
-const routeWithDoubleSlashes = '//api//v1/teams'
+describe('sanitizeUrl', () => {
+  it('should remove double slashes from the URL', () => {
+    const url = 'http://example.com//path//to//resource'
+    const sanitizedUrl = sanitizeUrl(url)
+    expect(sanitizedUrl.toString()).toBe('http://example.com/path/to/resource')
+  })
 
-const input = `${origin}${routeWithDoubleSlashes}`
-const output = `${origin}${route}`
-
-test('should return remove double slashes after the protocol', () => {
-  const result = sanitizeUrl(`https://${input}`)
-  const expected = new URL(`https://${output}`)
-  expect(result).toStrictEqual(expected)
-})
-
-test('should throw an error if the protocol is not http or https', () => {
-  // TODO: create a custom error class to throw and test for it here
-  expect(() => sanitizeUrl('ftp://${input}')).toThrow()
+  it('should not modify URLs without double slashes', () => {
+    const url = 'http://example.com/path/to/resource'
+    const sanitizedUrl = sanitizeUrl(url)
+    expect(sanitizedUrl.toString()).toBe(url)
+  })
 })

--- a/src/utils/sanitizeUrl.ts
+++ b/src/utils/sanitizeUrl.ts
@@ -9,19 +9,9 @@
  * @returns {URL} The sanitized URL.
  */
 const sanitizeUrl = (url: string): URL => {
-  // split the url into the protocol and the rest of the url
-  const [protocol, rest] = url.split('://')
-
-  // validate that the protocol is either http or https
-  if (protocol !== 'https' && protocol !== 'http') {
-    throw new Error(`Invalid URL: ${url} (invalid/missing protocol)`)
-  }
-
-  // replace double slashes after the protocol with single slashes
-  const sanitized = rest.replace(/\/\//g, '/')
-
-  // return the sanitized URL with the protocol
-  return new URL(`${protocol}://${sanitized}`)
+  const { origin, pathname, search, hash } = new URL(url)
+  const sanitizedPath = pathname.replace(/\/{2,}/g, '/')
+  return new URL(`${origin}${sanitizedPath}${search}${hash}`)
 }
 
 export default sanitizeUrl


### PR DESCRIPTION
## Summary

This PR fixes the `sanitizeUrl` util function to support more than just http and https protocols.

### Added

- n/a

### Changed

- `src/utils/sanitizeUrl`

### Deprecated

- n/a

### Removed

- n/a

### Fixed

- n/a

## How to test

- `yarn test` (tests pass if the github workflow is passing, no action needed)

**Test Coverage:**

```
----------------|---------|----------|---------|---------|------------------
File            | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------|---------|----------|---------|---------|------------------
All files       |     100 |      100 |     100 |     100 |
 sanitizeUrl.ts |     100 |      100 |     100 |     100 |
----------------|---------|----------|---------|---------|------------------
```