### PR TITLE
fix(views/SignIn): add missing autocomplete username

### DIFF
--- a/src/views/SignIn/SignIn.tsx
+++ b/src/views/SignIn/SignIn.tsx
@@ -113,7 +113,6 @@ const SignIn = () => {
               component="form"
               id="login-form"
               role="form"
-              autoComplete="off"
               onSubmit={handleSubmit}
               spacing={3}
             >
@@ -121,6 +120,7 @@ const SignIn = () => {
                 control={control}
                 name="email"
                 InputProps={{
+                  autoComplete: 'username',
                   placeholder: 'admin@cms.gov',
                 }}
               />


### PR DESCRIPTION
## Summary

This PR adds `autocomplete="username"` attribute to the email field in the signin form, which was missed in #114

### Added

<!-- List new features or components. Include a screenshot for new visual elements. -->

### Changed

- Adds an autocomplete attribute to the email field in `views/SignIn`
- Removes the `autoComplete="off"` prop from the form element

### Deprecated

<!-- List once-stable features or components to be deprecated in this PR. -->

### Removed

<!-- List deprecated features or components removed in this PR. -->

### Fixed

- Fixes the console warning:
  ```
  [DOM] Input elements should have autocomplete attributes (suggested: "username"): (More info: https://goo.gl/9p2vKq) <input aria-invalid=​"false" id=​"email-input" placeholder=​"admin@cms.gov" type=​"text" aria-labelledby=​"email-label" class=​"MuiInputBase-input MuiOutlinedInput-input css-lcbzx0-MuiInputBase-input-MuiOutlinedInput-input" value>​…​</input>​
  ```

## How to test

- yarn start
- go to the login screen
- confirm that you can autofill the fields
- confirm there is no warning in the console
